### PR TITLE
Correct the pip install command used to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The doctests in the code provide more examples.
 ## Installation
 
 ```bash
-pip install pylru
+pip install py_lru_cache
 ```
 
 ## When does cache eviction occur?


### PR DESCRIPTION
The module is not called pylru in pip. It is actually py_lru_cache. The installed module name is still lru.